### PR TITLE
On Linux and Windows mesh-inspector is a single window application

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,9 @@ main(int argc, char * argv[])
 
     const QStringList args = parser.positionalArguments();
 
+#ifdef __APPLE__
     app.setQuitOnLastWindowClosed(false);
+#endif
     app.setWindowIcon(QIcon(":/resources/app-icon.png"));
     MainWindow w;
     w.show();


### PR DESCRIPTION
On macOS, closing the window should not terminate the application.
Applications are terminated from menu or via Cmd+Q. However, on Windows
and Linux, closing the window means to terminate the application.

Closes #74
