### PR TITLE
Fixing reloading of mesh files

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -683,7 +683,8 @@ MainWindow::onFileChanged(const QString & path)
 void
 MainWindow::onReloadFile()
 {
-    loadFile(this->model->getFileName());
+    QString file_name = this->model->getFileName();
+    loadFile(file_name);
 }
 
 void


### PR DESCRIPTION
When mesh file was externally changed and user wished to reload it, the code
would end up in an infinite loop.  This was caused by a calling Model::clear()
(which clear the name of a loaded file) during the reload process. The file name
was obtained by a reference and further passed into loadFile. Thus, clearing the
file name had an adverse effect on the code that was using the aforementioned
reference.  Fixing this by creating a copy of the file name, so the file name
does not get lost.

Closes #86
