### PR TITLE
bug-fix

### DIFF
--- a/src/blockobject.cpp
+++ b/src/blockobject.cpp
@@ -46,7 +46,6 @@ BlockObject::BlockObject(vtkAlgorithmOutput * alg_output, vtkCamera * camera) :
         update();
     }
 
-    this->actor->SetScale(0.999);
     this->actor->VisibilityOn();
 
     this->color = QColor::fromRgbF(1., 1., 1.);

--- a/src/sidesetobject.cpp
+++ b/src/sidesetobject.cpp
@@ -1,3 +1,9 @@
 #include "sidesetobject.h"
+#include "vtkMapper.h"
 
-SideSetObject::SideSetObject(vtkAlgorithmOutput * alg_output) : MeshObject(alg_output) {}
+SideSetObject::SideSetObject(vtkAlgorithmOutput * alg_output) : MeshObject(alg_output)
+{
+    mapper->SetRelativeCoincidentTopologyLineOffsetParameters(-1, -1);
+    mapper->SetRelativeCoincidentTopologyPolygonOffsetParameters(-1, -1);
+    mapper->SetRelativeCoincidentTopologyPointOffsetParameter(-1);
+}

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -425,15 +425,21 @@ View::setSideSetProperties(SideSetObject * sideset)
     property->SetColor(SIDESET_CLR.redF(), SIDESET_CLR.greenF(), SIDESET_CLR.blueF());
     property->SetEdgeVisibility(false);
     property->LightingOff();
-    if (this->render_mode == SHADED || this->render_mode == SHADED_WITH_EDGES) {
+    if (this->render_mode == SHADED_WITH_EDGES) {
         property->SetEdgeColor(SIDESET_EDGE_CLR.redF(),
                                SIDESET_EDGE_CLR.greenF(),
                                SIDESET_EDGE_CLR.blueF());
-        if (this->render_mode == SHADED_WITH_EDGES) {
-            property->SetLineWidth(this->main_window->HIDPI(EDGE_WIDTH));
-            property->SetEdgeVisibility(true);
-        }
+        property->SetLineWidth(this->main_window->HIDPI(EDGE_WIDTH));
+        property->SetEdgeVisibility(true);
     }
+    else {
+        // this is a trick to prevent flickering between underlying block surface and the
+        // side-set surface
+        property->SetLineWidth(0);
+        property->SetEdgeColor(SIDESET_CLR.redF(), SIDESET_CLR.greenF(), SIDESET_CLR.blueF());
+        property->SetEdgeVisibility(true);
+    }
+    property->SetBackfaceCulling(true);
 }
 
 void


### PR DESCRIPTION
Fixing a long-standing problem with side set high-lighting. We were
scaling down the volumetric blocks, so that the side set could be
drawn "above" it.  This meant that we were reporting incorrect domain
dimensions. This also meant that on large domains the side sets were
drawn slightly off, since the scaling error got big enough.
