### PR TITLE
Improving robustness of `vtkMshReader`

### DIFF
--- a/src/vtkmshreader.cpp
+++ b/src/vtkmshreader.cpp
@@ -195,6 +195,14 @@ vtkMshReader::RequestInformation(vtkInformation * vtkNotUsed(request),
         vtkErrorMacro("" << e.what());
         return 0;
     }
+    catch (std::domain_error & e) {
+        vtkErrorMacro("" << e.what());
+        return 0;
+    }
+    catch (...) {
+        vtkErrorMacro("Unknown exception thrown");
+        return 0;
+    }
 
     // Advertise the SIL.
     outInfo->Set(vtkDataObject::SIL(), this->GetSIL());

--- a/src/vtkmshreader.cpp
+++ b/src/vtkmshreader.cpp
@@ -281,11 +281,14 @@ vtkMshReader::RequestData(vtkInformation * vtkNotUsed(request),
 void
 vtkMshReader::DetectDimensionality()
 {
-    this->Dimension = -1;
-    // the highest dimension of physical block is our mesh spatial dimension
-    for (auto & physBlk : this->Msh->get_physical_names()) {
-        this->Dimension = std::max(this->Dimension, physBlk.dimension);
-    }
+    if (!this->Msh->get_volume_entities().empty())
+        this->Dimension = 3;
+    else if (!this->Msh->get_surface_entities().empty())
+        this->Dimension = 2;
+    else if (!this->Msh->get_curve_entities().empty())
+        this->Dimension = 1;
+    else
+        this->Dimension = -1;
 }
 
 void

--- a/src/vtkmshreader.cpp
+++ b/src/vtkmshreader.cpp
@@ -293,7 +293,7 @@ vtkMshReader::ProcessMsh()
 {
     DetectDimensionality();
     BuildCoordinates();
-    ReadPhysicalEntites();
+    ReadPhysicalEntities();
 
     this->ElemBlkByDim.resize(4);
     for (const auto & eb : this->Msh->get_element_blocks())
@@ -315,7 +315,7 @@ vtkMshReader::ProcessMsh()
 }
 
 void
-vtkMshReader::ReadPhysicalEntites()
+vtkMshReader::ReadPhysicalEntities()
 {
     for (const auto & pe : this->Msh->get_physical_names()) {
         this->PhysEntByTag[pe.tag] = &pe;

--- a/src/vtkmshreader.h
+++ b/src/vtkmshreader.h
@@ -51,7 +51,7 @@ protected:
     RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
     int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
     void DetectDimensionality();
-    void ReadPhysicalEntites();
+    void ReadPhysicalEntities();
     void BuildCoordinates();
     void ProcessMsh();
     const std::vector<gmshparsercpp::MshFile::MultiDEntity> * GetEntitiesByDim(int dim);


### PR DESCRIPTION
- Fixing a typo in a function name
- Dimensionality of the mesh is based on the multiD entities, not physical entity names
- gmsh: also show blocks that do not have physical names
- Improving error handling in vtkMshReader

Refs #31