### PR TITLE
Fixing rendering of previously opened model

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -171,6 +171,7 @@ void
 View::clear()
 {
     this->renderer->RemoveAllViewProps();
+    render();
 }
 
 void


### PR DESCRIPTION
If we loaded a model and closed the window, the next time we opened
a new empty model via Cmd+N, we would see the previous render.
This fixes the problem by clearing the render buffer when the model
is closed.
