### PR TITLE
Improving memory management

### DIFF
--- a/src/blockobject.cpp
+++ b/src/blockobject.cpp
@@ -52,12 +52,7 @@ BlockObject::BlockObject(vtkAlgorithmOutput * alg_output, vtkCamera * camera) :
     this->setUpSilhouette(camera);
 }
 
-BlockObject::~BlockObject()
-{
-    this->silhouette->Delete();
-    this->silhouette_mapper->Delete();
-    this->silhouette_actor->Delete();
-}
+BlockObject::~BlockObject() {}
 
 void
 BlockObject::setUpCellQuality(vtkUnstructuredGrid * unstr_grid)
@@ -65,7 +60,7 @@ BlockObject::setUpCellQuality(vtkUnstructuredGrid * unstr_grid)
     this->grid = unstr_grid;
     auto n_cells = unstr_grid->GetNumberOfCells();
 
-    auto cell_quality = vtkDoubleArray::New();
+    auto cell_quality = vtkSmartPointer<vtkDoubleArray>::New();
     cell_quality->SetNumberOfTuples(n_cells);
     for (vtkIdType i = 0; i < n_cells; i++)
         cell_quality->SetValue(i, (double) i);
@@ -120,14 +115,14 @@ BlockObject::getUnstructuredGrid() const
 void
 BlockObject::setUpSilhouette(vtkCamera * camera)
 {
-    this->silhouette = vtkPolyDataSilhouette::New();
+    this->silhouette = vtkSmartPointer<vtkPolyDataSilhouette>::New();
     this->silhouette->SetInputData(this->mapper->GetInput());
     this->silhouette->SetCamera(camera);
 
-    this->silhouette_mapper = vtkPolyDataMapper::New();
+    this->silhouette_mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     this->silhouette_mapper->SetInputConnection(this->silhouette->GetOutputPort());
 
-    this->silhouette_actor = vtkActor::New();
+    this->silhouette_actor = vtkSmartPointer<vtkActor>::New();
     this->silhouette_actor->SetMapper(this->silhouette_mapper);
     this->silhouette_actor->VisibilityOff();
 

--- a/src/blockobject.h
+++ b/src/blockobject.h
@@ -38,9 +38,9 @@ protected:
     void setUpSilhouette(vtkCamera * camera);
 
     vtkUnstructuredGrid * grid;
-    vtkPolyDataSilhouette * silhouette;
-    vtkPolyDataMapper * silhouette_mapper;
-    vtkActor * silhouette_actor;
+    vtkSmartPointer<vtkPolyDataSilhouette> silhouette;
+    vtkSmartPointer<vtkPolyDataMapper> silhouette_mapper;
+    vtkSmartPointer<vtkActor> silhouette_actor;
     QColor color;
     double opacity;
 };

--- a/src/cliptool.cpp
+++ b/src/cliptool.cpp
@@ -97,8 +97,7 @@ ClipTool::onClip()
 void
 ClipTool::onClose()
 {
-    for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
+    for (auto & [id, block] : this->model->getBlocks()) {
         block->setClip(false);
     }
 }
@@ -106,8 +105,7 @@ ClipTool::onClose()
 void
 ClipTool::clipBlocks()
 {
-    for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
+    for (auto & [id, block] : this->model->getBlocks()) {
         block->setClip(true);
         block->setClipPlane(this->clip_plane);
     }
@@ -143,8 +141,7 @@ ClipTool::onPlaneMoved()
 void
 ClipTool::updateModelBlocks()
 {
-    for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
+    for (auto & [id, block] : this->model->getBlocks()) {
         block->setClipPlane(this->clip_plane);
         block->modified();
         block->update();

--- a/src/cliptool.cpp
+++ b/src/cliptool.cpp
@@ -13,7 +13,7 @@ ClipTool::ClipTool(MainWindow * main_wnd) :
     main_window(main_wnd),
     model(main_wnd->getModel()),
     widget(nullptr),
-    clip_plane(vtkPlane::New()),
+    clip_plane(vtkSmartPointer<vtkPlane>::New()),
     normal(0, 0, 1),
     normal_ori(1.)
 {
@@ -22,7 +22,6 @@ ClipTool::ClipTool(MainWindow * main_wnd) :
 ClipTool::~ClipTool()
 {
     delete this->widget;
-    this->clip_plane->Delete();
 }
 
 void

--- a/src/cliptool.h
+++ b/src/cliptool.h
@@ -6,6 +6,7 @@
 #include "clipwidget.h"
 #include <QObject>
 #include <QVector3D>
+#include "vtkSmartPointer.h"
 
 class MainWindow;
 class Model;
@@ -40,7 +41,7 @@ protected:
     MainWindow * main_window;
     Model *& model;
     ClipWidget * widget;
-    vtkPlane * clip_plane;
+    vtkSmartPointer<vtkPlane> clip_plane;
     QVector3D normal;
     float normal_ori;
 };

--- a/src/exodusiireader.cpp
+++ b/src/exodusiireader.cpp
@@ -3,21 +3,16 @@
 
 #include "exodusiireader.h"
 #include "vtkExodusIIReader.h"
+#include "vtkSmartPointer.h"
 
-ExodusIIReader::ExodusIIReader(const std::string & file_name) : Reader(file_name), reader(nullptr)
-{
-}
+ExodusIIReader::ExodusIIReader(const std::string & file_name) : Reader(file_name) {}
 
-ExodusIIReader::~ExodusIIReader()
-{
-    if (this->reader)
-        this->reader->Delete();
-}
+ExodusIIReader::~ExodusIIReader() {}
 
 void
 ExodusIIReader::load()
 {
-    this->reader = vtkExodusIIReader::New();
+    this->reader = vtkSmartPointer<vtkExodusIIReader>::New();
 
     this->reader->SetFileName(this->file_name.c_str());
     this->reader->UpdateInformation();

--- a/src/exodusiireader.h
+++ b/src/exodusiireader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "reader.h"
+#include "vtkSmartPointer.h"
 #include <map>
 
 class vtkExodusIIReader;
@@ -26,6 +27,6 @@ public:
 protected:
     void readBlockInfo();
 
-    vtkExodusIIReader * reader;
+    vtkSmartPointer<vtkExodusIIReader> reader;
     std::map<int, std::map<int, BlockInformation>> block_info;
 };

--- a/src/explodetool.cpp
+++ b/src/explodetool.cpp
@@ -54,7 +54,7 @@ ExplodeTool::onValueChanged(double value)
 {
     double dist = value / this->explode->range();
     for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
+        auto block = it.second;
         auto blk_cob = block->getCenterOfBounds();
         vtkVector3d dir;
         vtkMath::Subtract(blk_cob, this->model->getCenterOfBounds(), dir);

--- a/src/exporttool.cpp
+++ b/src/exporttool.cpp
@@ -61,13 +61,13 @@ ExportTool::onExportAsPng()
     auto fname = getFileName("Export to PNG", "PNG files (*.png)", "png");
     if (!fname.isNull()) {
         auto view = this->main_window->getView();
-        auto * windowToImageFilter = vtkWindowToImageFilter::New();
+        auto windowToImageFilter = vtkSmartPointer<vtkWindowToImageFilter>::New();
         windowToImageFilter->SetInput(view->getRenderWindow());
         windowToImageFilter->SetInputBufferTypeToRGBA();
         windowToImageFilter->ReadFrontBufferOff();
         windowToImageFilter->Update();
 
-        auto * writer = vtkPNGWriter::New();
+        auto writer = vtkSmartPointer<vtkPNGWriter>::New();
         writer->SetFileName(fname.toStdString().c_str());
         writer->SetInputConnection(windowToImageFilter->GetOutputPort());
         writer->Write();
@@ -86,12 +86,12 @@ ExportTool::onExportAsJpg()
     auto fname = getFileName("Export to JPG", "JPG files (*.jpg)", "jpg");
     if (!fname.isNull()) {
         auto view = this->main_window->getView();
-        auto * windowToImageFilter = vtkWindowToImageFilter::New();
+        auto windowToImageFilter = vtkSmartPointer<vtkWindowToImageFilter>::New();
         windowToImageFilter->SetInput(view->getRenderWindow());
         windowToImageFilter->ReadFrontBufferOff();
         windowToImageFilter->Update();
 
-        auto * writer = vtkJPEGWriter::New();
+        auto writer = vtkSmartPointer<vtkJPEGWriter>::New();
         writer->SetFileName(fname.toStdString().c_str());
         writer->SetInputConnection(windowToImageFilter->GetOutputPort());
         writer->Write();
@@ -115,7 +115,7 @@ ExportTool::onExportAsPdf()
         auto file_prefix = QFileInfo(path, base_name).absoluteFilePath();
 
         auto view = this->main_window->getView();
-        auto * writer = vtkGL2PSExporter::New();
+        auto writer = vtkSmartPointer<vtkGL2PSExporter>::New();
         writer->SetFileFormatToPDF();
         writer->DrawBackgroundOff();
         writer->SetSortToBSP();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -154,7 +154,7 @@ MainWindow::getModel()
     return this->model;
 }
 
-const BlockObject *
+const std::shared_ptr<BlockObject>
 MainWindow::getSelectedBlock()
 {
     return this->select_tool->getSelectedBlock();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -47,7 +47,7 @@ public:
     View *& getView();
     InfoView *& getInfoView();
     Model *& getModel();
-    const BlockObject * getSelectedBlock();
+    const std::shared_ptr<BlockObject> getSelectedBlock();
 
     template <typename T>
     inline qreal

--- a/src/meshobject.cpp
+++ b/src/meshobject.cpp
@@ -17,24 +17,24 @@
 
 MeshObject::MeshObject(vtkAlgorithmOutput * alg_output) :
     clipping(false),
-    clipper(vtkPolyDataPlaneClipper::New()),
-    clip_plane(vtkPlane::New()),
-    clipped_actor(vtkActor::New())
+    clipper(vtkSmartPointer<vtkPolyDataPlaneClipper>::New()),
+    clip_plane(vtkSmartPointer<vtkPlane>::New()),
+    clipped_actor(vtkSmartPointer<vtkActor>::New())
 {
     auto * algoritm = alg_output->GetProducer();
     this->data_object = algoritm->GetOutputDataObject(0);
 
     if (dynamic_cast<vtkMultiBlockDataSet *>(this->data_object)) {
-        this->geometry = vtkCompositeDataGeometryFilter::New();
-        this->mapper = vtkPolyDataMapper::New();
-        this->clipped_away_mapper = vtkPolyDataMapper::New();
-        this->cut_away_geometry = vtkCompositeDataGeometryFilter::New();
+        this->geometry = vtkSmartPointer<vtkCompositeDataGeometryFilter>::New();
+        this->mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+        this->clipped_away_mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+        this->cut_away_geometry = vtkSmartPointer<vtkCompositeDataGeometryFilter>::New();
     }
     else {
-        this->geometry = vtkGeometryFilter::New();
-        this->mapper = vtkDataSetMapper::New();
-        this->clipped_away_mapper = vtkDataSetMapper::New();
-        this->cut_away_geometry = vtkGeometryFilter::New();
+        this->geometry = vtkSmartPointer<vtkGeometryFilter>::New();
+        this->mapper = vtkSmartPointer<vtkDataSetMapper>::New();
+        this->clipped_away_mapper = vtkSmartPointer<vtkDataSetMapper>::New();
+        this->cut_away_geometry = vtkSmartPointer<vtkGeometryFilter>::New();
     }
 
     this->geometry->SetInputConnection(0, alg_output);
@@ -44,7 +44,7 @@ MeshObject::MeshObject(vtkAlgorithmOutput * alg_output) :
     this->mapper->SetScalarModeToUsePointFieldData();
     this->mapper->InterpolateScalarsBeforeMappingOn();
 
-    this->actor = vtkActor::New();
+    this->actor = vtkSmartPointer<vtkActor>::New();
     this->actor->SetMapper(this->mapper);
     this->actor->VisibilityOff();
 
@@ -53,16 +53,11 @@ MeshObject::MeshObject(vtkAlgorithmOutput * alg_output) :
     this->bounding_box.GetCenter(center);
     this->center_of_bounds = vtkVector3d(center[0], center[1], center[2]);
 
-    this->cutter = vtkPlaneCutter::New();
+    this->cutter = vtkSmartPointer<vtkPlaneCutter>::New();
     this->cutter->SetInputData(this->data_object);
 }
 
-MeshObject::~MeshObject()
-{
-    this->geometry->Delete();
-    this->mapper->Delete();
-    this->actor->Delete();
-}
+MeshObject::~MeshObject() {}
 
 bool
 MeshObject::visible()

--- a/src/meshobject.h
+++ b/src/meshobject.h
@@ -5,6 +5,7 @@
 
 #include "vtkVector.h"
 #include "vtkBoundingBox.h"
+#include "vtkSmartPointer.h"
 
 class vtkDataObject;
 class vtkAlgorithmOutput;
@@ -45,17 +46,17 @@ protected:
     vtkVector3d computeCenterOfBounds();
 
     vtkDataObject * data_object;
-    vtkPolyDataAlgorithm * geometry;
-    vtkMapper * mapper;
-    vtkActor * actor;
+    vtkSmartPointer<vtkPolyDataAlgorithm> geometry;
+    vtkSmartPointer<vtkMapper> mapper;
+    vtkSmartPointer<vtkActor> actor;
     vtkBoundingBox bounding_box;
     vtkVector3d center_of_bounds;
 
     bool clipping;
-    vtkPolyDataPlaneClipper * clipper;
-    vtkPlane * clip_plane;
-    vtkMapper * clipped_away_mapper;
-    vtkActor * clipped_actor;
-    vtkPlaneCutter * cutter;
-    vtkPolyDataAlgorithm * cut_away_geometry;
+    vtkSmartPointer<vtkPolyDataPlaneClipper> clipper;
+    vtkSmartPointer<vtkPlane> clip_plane;
+    vtkSmartPointer<vtkMapper> clipped_away_mapper;
+    vtkSmartPointer<vtkActor> clipped_actor;
+    vtkSmartPointer<vtkPlaneCutter> cutter;
+    vtkSmartPointer<vtkPolyDataAlgorithm> cut_away_geometry;
 };

--- a/src/meshqualitytool.cpp
+++ b/src/meshqualitytool.cpp
@@ -100,9 +100,7 @@ MeshQualityTool::updateLocation()
 void
 MeshQualityTool::onMetricChanged(int metric_id)
 {
-    for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
-
+    for (auto & [id, block] : this->model->getBlocks()) {
         auto grid = block->getUnstructuredGrid();
         auto cell_quality = vtkSmartPointer<vtkCellQuality>::New();
         switch (metric_id) {
@@ -132,8 +130,7 @@ MeshQualityTool::onMetricChanged(int metric_id)
     double range[2];
     getCellQualityRange(range);
 
-    for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
+    for (auto & [id, block] : this->model->getBlocks()) {
         setBlockMeshQualityProperties(block, range);
         block->modified();
         block->update();
@@ -145,8 +142,7 @@ MeshQualityTool::getCellQualityRange(double range[])
 {
     range[0] = std::numeric_limits<double>::max();
     range[1] = -std::numeric_limits<double>::max();
-    for (auto & it : this->model->getBlocks()) {
-        auto * block = it.second;
+    for (auto & [id, block] : this->model->getBlocks()) {
         auto cell_data = block->getCellData();
 
         double block_range[2];
@@ -159,8 +155,7 @@ MeshQualityTool::getCellQualityRange(double range[])
 void
 MeshQualityTool::onClose()
 {
-    for (auto & it : this->model->getBlocks()) {
-        BlockObject * block = it.second;
+    for (auto & [id, block] : this->model->getBlocks()) {
         auto * mapper = block->getMapper();
         mapper->ScalarVisibilityOff();
         block->update();
@@ -411,7 +406,7 @@ MeshQualityTool::setupColorBar()
 }
 
 void
-MeshQualityTool::setBlockMeshQualityProperties(BlockObject * block, double range[])
+MeshQualityTool::setBlockMeshQualityProperties(std::shared_ptr<BlockObject> block, double range[])
 {
     auto * property = block->getProperty();
     property->SetRepresentationToSurface();

--- a/src/meshqualitytool.cpp
+++ b/src/meshqualitytool.cpp
@@ -34,7 +34,6 @@ MeshQualityTool::MeshQualityTool(MainWindow * main_wnd) :
 MeshQualityTool::~MeshQualityTool()
 {
     delete this->mesh_quality;
-    this->lut->Delete();
 }
 
 void
@@ -105,7 +104,7 @@ MeshQualityTool::onMetricChanged(int metric_id)
         auto * block = it.second;
 
         auto grid = block->getUnstructuredGrid();
-        auto cell_quality = vtkCellQuality::New();
+        auto cell_quality = vtkSmartPointer<vtkCellQuality>::New();
         switch (metric_id) {
         default:
         case MESH_METRIC_JACOBIAN:
@@ -128,7 +127,6 @@ MeshQualityTool::onMetricChanged(int metric_id)
         cell_quality->Update();
         auto out = cell_quality->GetOutput();
         grid->GetCellData()->AddArray(out->GetCellData()->GetArray("CellQuality"));
-        cell_quality->Delete();
     }
 
     double range[2];
@@ -358,7 +356,7 @@ MeshQualityTool::setupLookupTable()
                         0.41389999999999999,
                         1. };
 
-    this->lut = vtkLookupTable::New();
+    this->lut = vtkSmartPointer<vtkLookupTable>::New();
     this->lut->SetNumberOfTableValues(43);
     double * clr_ptr = colors;
     for (int i = 0; i < 43; i++, clr_ptr += 4)
@@ -370,7 +368,7 @@ MeshQualityTool::setupLookupTable()
 void
 MeshQualityTool::setupColorBar()
 {
-    this->color_bar = vtkScalarBarActor::New();
+    this->color_bar = vtkSmartPointer<vtkScalarBarActor>::New();
     this->color_bar->VisibilityOff();
     this->color_bar->SetNumberOfLabels(5);
     this->color_bar->SetLookupTable(this->lut);

--- a/src/meshqualitytool.h
+++ b/src/meshqualitytool.h
@@ -37,7 +37,7 @@ protected:
     void setupLookupTable();
     void setupColorBar();
     void getCellQualityRange(double range[]);
-    void setBlockMeshQualityProperties(BlockObject * block, double range[]);
+    void setBlockMeshQualityProperties(std::shared_ptr<BlockObject> block, double range[]);
 
     MainWindow * main_window;
     Model *& model;

--- a/src/meshqualitytool.h
+++ b/src/meshqualitytool.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QObject>
+#include "vtkSmartPointer.h"
 
 class MainWindow;
 class Model;
@@ -42,8 +43,8 @@ protected:
     Model *& model;
     View *& view;
     MeshQualityWidget * mesh_quality;
-    vtkLookupTable * lut;
-    vtkScalarBarActor * color_bar;
+    vtkSmartPointer<vtkLookupTable> lut;
+    vtkSmartPointer<vtkScalarBarActor> color_bar;
 
 public:
     static const char * MESH_QUALITY_FIELD_NAME;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -103,11 +103,7 @@ Model::clear()
         delete it.second;
     this->node_sets.clear();
 
-    for (auto & eb : this->extract_blocks)
-        eb->Delete();
     this->extract_blocks.clear();
-    for (auto & ec : this->extract_mat_blocks)
-        ec->Delete();
     this->extract_mat_blocks.clear();
 
     this->file_name = QString();
@@ -146,7 +142,7 @@ Model::addBlocks()
     for (auto & binfo : this->reader->getBlocks()) {
         BlockObject * block = nullptr;
         if (binfo.multiblock_index != -1) {
-            vtkExtractBlock * eb = vtkExtractBlock::New();
+            auto eb = vtkSmartPointer<vtkExtractBlock>::New();
             eb->SetInputConnection(this->reader->getVtkOutputPort());
             eb->AddIndex(binfo.multiblock_index);
             eb->Update();
@@ -155,7 +151,7 @@ Model::addBlocks()
             block = new BlockObject(eb->GetOutputPort(), camera);
         }
         else if (binfo.material_index != -1) {
-            auto eb = vtkExtractMaterialBlock::New();
+            auto eb = vtkSmartPointer<vtkExtractMaterialBlock>::New();
             eb->SetInputConnection(this->reader->getVtkOutputPort());
             eb->SetBlockId(binfo.material_index);
             eb->Update();
@@ -176,7 +172,7 @@ void
 Model::addSideSets()
 {
     for (auto & finfo : this->reader->getSideSets()) {
-        auto * eb = vtkExtractBlock::New();
+        auto eb = vtkSmartPointer<vtkExtractBlock>::New();
         eb->SetInputConnection(this->reader->getVtkOutputPort());
         eb->AddIndex(finfo.multiblock_index);
         eb->Update();
@@ -193,7 +189,7 @@ void
 Model::addNodeSets()
 {
     for (auto & ninfo : reader->getNodeSets()) {
-        auto * eb = vtkExtractBlock::New();
+        auto eb = vtkSmartPointer<vtkExtractBlock>::New();
         eb->SetInputConnection(this->reader->getVtkOutputPort());
         eb->AddIndex(ninfo.multiblock_index);
         eb->Update();

--- a/src/model.h
+++ b/src/model.h
@@ -32,14 +32,14 @@ public:
     explicit Model(MainWindow * main_window);
     ~Model() override;
 
-    const std::map<int, BlockObject *> & getBlocks() const;
-    const std::map<int, SideSetObject *> & getSideSets() const;
-    const std::map<int, NodeSetObject *> & getNodeSets() const;
+    const std::map<int, std::shared_ptr<BlockObject>> & getBlocks() const;
+    const std::map<int, std::shared_ptr<SideSetObject>> & getSideSets() const;
+    const std::map<int, std::shared_ptr<NodeSetObject>> & getNodeSets() const;
     const vtkVector3d & getCenterOfBounds() const;
 
-    BlockObject * getBlock(int block_id);
-    SideSetObject * getSideSet(int sideset_id);
-    NodeSetObject * getNodeSet(int nodeset_id);
+    std::shared_ptr<BlockObject> getBlock(int block_id);
+    std::shared_ptr<SideSetObject> getSideSet(int sideset_id);
+    std::shared_ptr<NodeSetObject> getNodeSet(int nodeset_id);
 
     int blockActorToId(vtkActor * actor);
 
@@ -83,9 +83,9 @@ protected:
 
     std::vector<vtkSmartPointer<vtkExtractBlock>> extract_blocks;
     std::vector<vtkSmartPointer<vtkExtractMaterialBlock>> extract_mat_blocks;
-    std::map<int, BlockObject *> blocks;
-    std::map<int, SideSetObject *> side_sets;
-    std::map<int, NodeSetObject *> node_sets;
+    std::map<int, std::shared_ptr<BlockObject>> blocks;
+    std::map<int, std::shared_ptr<SideSetObject>> side_sets;
+    std::map<int, std::shared_ptr<NodeSetObject>> node_sets;
 
     /// Bounding box
     vtkBoundingBox bbox;

--- a/src/model.h
+++ b/src/model.h
@@ -75,7 +75,7 @@ protected:
     void addSideSets();
     void addNodeSets();
     void computeTotalBoundingBox();
-    Reader * createReader(const QString & file_name);
+    std::shared_ptr<Reader> createReader(const QString & file_name);
 
     MainWindow * main_window;
     View *& view;
@@ -92,8 +92,8 @@ protected:
     /// center of bounding box of the whole mesh
     vtkVector3d center_of_bounds;
 
-    LoadThread * load_thread;
-    Reader * reader;
+    std::shared_ptr<LoadThread> load_thread;
+    std::shared_ptr<Reader> reader;
     QString file_name;
     QFileSystemWatcher * file_watcher;
     bool reset_camera_on_load;

--- a/src/model.h
+++ b/src/model.h
@@ -81,8 +81,8 @@ protected:
     View *& view;
     InfoView *& info_view;
 
-    std::vector<vtkExtractBlock *> extract_blocks;
-    std::vector<vtkExtractMaterialBlock *> extract_mat_blocks;
+    std::vector<vtkSmartPointer<vtkExtractBlock>> extract_blocks;
+    std::vector<vtkSmartPointer<vtkExtractMaterialBlock>> extract_mat_blocks;
     std::map<int, BlockObject *> blocks;
     std::map<int, SideSetObject *> side_sets;
     std::map<int, NodeSetObject *> node_sets;

--- a/src/mshreader.cpp
+++ b/src/mshreader.cpp
@@ -6,16 +6,12 @@
 
 MSHReader::MSHReader(const std::string & file_name) : Reader(file_name), reader(nullptr) {}
 
-MSHReader::~MSHReader()
-{
-    if (this->reader)
-        this->reader->Delete();
-}
+MSHReader::~MSHReader() {}
 
 void
 MSHReader::load()
 {
-    this->reader = vtkMshReader::New();
+    this->reader = vtkSmartPointer<vtkMshReader>::New();
 
     this->reader->SetFileName(this->file_name.c_str());
     this->reader->UpdateInformation();

--- a/src/mshreader.h
+++ b/src/mshreader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "reader.h"
+#include "vtkSmartPointer.h"
 #include <map>
 
 class vtkMshReader;
@@ -26,6 +27,6 @@ public:
 protected:
     void readBlockInfo();
 
-    vtkMshReader * reader;
+    vtkSmartPointer<vtkMshReader> reader;
     std::map<int, std::map<int, BlockInformation>> block_info;
 };

--- a/src/objreader.cpp
+++ b/src/objreader.cpp
@@ -9,16 +9,12 @@
 
 OBJReader::OBJReader(const std::string & file_name) : Reader(file_name), reader(nullptr) {}
 
-OBJReader::~OBJReader()
-{
-    if (this->reader)
-        this->reader->Delete();
-}
+OBJReader::~OBJReader() {}
 
 void
 OBJReader::load()
 {
-    this->reader = vtkOBJReader::New();
+    this->reader = vtkSmartPointer<vtkOBJReader>::New();
 
     this->reader->SetFileName(this->file_name.c_str());
     this->reader->Update();

--- a/src/objreader.h
+++ b/src/objreader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "reader.h"
+#include "vtkSmartPointer.h"
 #include <map>
 
 class vtkOBJReader;
@@ -26,6 +27,6 @@ public:
 protected:
     void readBlockInfo();
 
-    vtkOBJReader * reader;
+    vtkSmartPointer<vtkOBJReader> reader;
     std::map<int, BlockInformation> block_info;
 };

--- a/src/selection.h
+++ b/src/selection.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "vtkType.h"
+#include "vtkSmartPointer.h"
 
 class vtkActor;
 class vtkDataSetMapper;
@@ -27,12 +28,11 @@ public:
 
 protected:
     void setSelection(vtkSelectionNode * selection_node);
-    void freeSelection();
 
-    vtkPolyDataAlgorithm * geometry;
-    vtkExtractSelection * extract_selection;
-    vtkUnstructuredGrid * selected;
-    vtkDataSetMapper * mapper;
-    vtkActor * actor;
-    vtkSelection * selection;
+    vtkSmartPointer<vtkPolyDataAlgorithm> geometry;
+    vtkSmartPointer<vtkExtractSelection> extract_selection;
+    vtkSmartPointer<vtkUnstructuredGrid> selected;
+    vtkSmartPointer<vtkDataSetMapper> mapper;
+    vtkSmartPointer<vtkActor> actor;
+    vtkSmartPointer<vtkSelection> selection;
 };

--- a/src/selecttool.cpp
+++ b/src/selecttool.cpp
@@ -79,7 +79,7 @@ SelectTool::~SelectTool()
     delete this->mode_select_action_group;
 }
 
-const BlockObject *
+const std::shared_ptr<BlockObject>
 SelectTool::getSelectedBlock() const
 {
     return this->selected_block;
@@ -183,7 +183,7 @@ SelectTool::onBlockSelectionChanged(int block_id)
     auto blocks = this->model->getBlocks();
     const auto & it = blocks.find(block_id);
     if (it != blocks.end()) {
-        BlockObject * block = it->second;
+        auto block = it->second;
         auto info = QString("Block: %1\n"
                             "Cells: %2\n"
                             "Points: %3")
@@ -202,7 +202,7 @@ SelectTool::onSideSetSelectionChanged(int sideset_id)
     auto side_sets = this->model->getSideSets();
     const auto & it = side_sets.find(sideset_id);
     if (it != side_sets.end()) {
-        auto * sideset = it->second;
+        auto sideset = it->second;
         auto info = QString("Side set: %1\n"
                             "Cells: %2\n"
                             "Points: %3")
@@ -221,7 +221,7 @@ SelectTool::onNodeSetSelectionChanged(int nodeset_id)
     auto node_sets = this->model->getNodeSets();
     const auto & it = node_sets.find(nodeset_id);
     if (it != node_sets.end()) {
-        auto * nodeset = it->second;
+        auto nodeset = it->second;
         auto info = QString("Node set: %1\n"
                             "Points: %2")
                         .arg(nodeset_id)
@@ -266,7 +266,7 @@ SelectTool::selectBlock(const QPoint & pt)
         auto * actor = dynamic_cast<vtkActor *>(picker->GetViewProp());
         if (actor) {
             auto blk_id = this->model->blockActorToId(actor);
-            auto * block = this->model->getBlock(blk_id);
+            auto block = this->model->getBlock(blk_id);
             onBlockSelectionChanged(blk_id);
             this->selected_block = block;
             auto highlighted = this->selected_block == this->highlighted_block;
@@ -367,7 +367,7 @@ SelectTool::highlightBlock(const QPoint & pt)
         auto * actor = dynamic_cast<vtkActor *>(picker->GetViewProp());
         if (actor) {
             auto blk_id = this->model->blockActorToId(actor);
-            auto * block = this->model->getBlock(blk_id);
+            auto block = this->model->getBlock(blk_id);
             if (block) {
                 this->highlighted_block = block;
                 auto selected = this->highlighted_block == this->selected_block;

--- a/src/selecttool.cpp
+++ b/src/selecttool.cpp
@@ -261,7 +261,7 @@ SelectTool::clear()
 void
 SelectTool::selectBlock(const QPoint & pt)
 {
-    auto * picker = vtkPropPicker::New();
+    auto picker = vtkSmartPointer<vtkPropPicker>::New();
     if (picker->PickProp(pt.x(), pt.y(), this->view->getRenderer())) {
         auto * actor = dynamic_cast<vtkActor *>(picker->GetViewProp());
         if (actor) {
@@ -273,13 +273,12 @@ SelectTool::selectBlock(const QPoint & pt)
             this->view->setBlockProperties(block, true, highlighted);
         }
     }
-    picker->Delete();
 }
 
 void
 SelectTool::selectCell(const QPoint & pt)
 {
-    auto * picker = vtkCellPicker::New();
+    auto picker = vtkSmartPointer<vtkCellPicker>::New();
     if (picker->Pick(pt.x(), pt.y(), 0, this->view->getRenderer())) {
         auto cell_id = picker->GetCellId();
         this->selection->selectCell(cell_id);
@@ -292,13 +291,12 @@ SelectTool::selectCell(const QPoint & pt)
             QString("Element ID: %1\nType: %2").arg(cell_id).arg(cellTypeToName(cell_type));
         showSelectedMeshEntity(nfo);
     }
-    picker->Delete();
 }
 
 void
 SelectTool::selectPoint(const QPoint & pt)
 {
-    auto * picker = vtkPointPicker::New();
+    auto picker = vtkSmartPointer<vtkPointPicker>::New();
     if (picker->Pick(pt.x(), pt.y(), 0, this->view->getRenderer())) {
         auto point_id = picker->GetPointId();
         this->selection->selectPoint(point_id);
@@ -322,7 +320,6 @@ SelectTool::selectPoint(const QPoint & pt)
             showSelectedMeshEntity(nfo);
         }
     }
-    picker->Delete();
 }
 
 void
@@ -365,7 +362,7 @@ SelectTool::highlightBlock(const QPoint & pt)
         this->view->setBlockProperties(this->highlighted_block, selected, false);
     }
 
-    auto * picker = vtkPropPicker::New();
+    auto picker = vtkSmartPointer<vtkPropPicker>::New();
     if (picker->PickProp(pt.x(), pt.y(), this->view->getRenderer())) {
         auto * actor = dynamic_cast<vtkActor *>(picker->GetViewProp());
         if (actor) {
@@ -381,13 +378,12 @@ SelectTool::highlightBlock(const QPoint & pt)
     else if (this->highlighted_block) {
         this->highlighted_block = nullptr;
     }
-    picker->Delete();
 }
 
 void
 SelectTool::highlightCell(const QPoint & pt)
 {
-    auto * picker = vtkCellPicker::New();
+    auto picker = vtkSmartPointer<vtkCellPicker>::New();
     if (picker->Pick(pt.x(), pt.y(), 0, this->view->getRenderer())) {
         auto cell_id = picker->GetCellId();
         this->highlight->selectCell(cell_id);
@@ -395,13 +391,12 @@ SelectTool::highlightCell(const QPoint & pt)
     }
     else
         this->highlight->clear();
-    picker->Delete();
 }
 
 void
 SelectTool::highlightPoint(const QPoint & pt)
 {
-    auto * picker = vtkPointPicker::New();
+    auto picker = vtkSmartPointer<vtkPointPicker>::New();
     if (picker->Pick(pt.x(), pt.y(), 0, this->view->getRenderer())) {
         auto point_id = picker->GetPointId();
         this->highlight->selectPoint(point_id);
@@ -409,7 +404,6 @@ SelectTool::highlightPoint(const QPoint & pt)
     }
     else
         this->highlight->clear();
-    picker->Delete();
 }
 
 void

--- a/src/selecttool.cpp
+++ b/src/selecttool.cpp
@@ -130,14 +130,12 @@ SelectTool::update()
 {
     auto output_port = this->model->getVtkOutputPort();
 
-    delete this->selection;
-    this->selection = new Selection(output_port);
+    this->selection = std::make_shared<Selection>(output_port);
     setSelectionProperties();
     auto renderer = this->view->getRenderer();
     renderer->AddActor(this->selection->getActor());
 
-    delete this->highlight;
-    this->highlight = new Selection(output_port);
+    this->highlight = std::make_shared<Selection>(output_port);
     setHighlightProperties();
     renderer->AddActor(this->highlight->getActor());
 }
@@ -248,14 +246,8 @@ SelectTool::onSelectModeTriggered(QAction * action)
 void
 SelectTool::clear()
 {
-    if (this->selection) {
-        delete this->selection;
-        this->selection = nullptr;
-    }
-    if (this->highlight) {
-        delete this->highlight;
-        this->highlight = nullptr;
-    }
+    this->selection = nullptr;
+    this->highlight = nullptr;
 }
 
 void

--- a/src/selecttool.h
+++ b/src/selecttool.h
@@ -67,9 +67,9 @@ protected:
     QActionGroup * mode_select_action_group;
 
     EModeSelect select_mode;
-    Selection * selection;
+    std::shared_ptr<Selection> selection;
     std::shared_ptr<BlockObject> selected_block;
-    Selection * highlight;
+    std::shared_ptr<Selection> highlight;
     std::shared_ptr<BlockObject> highlighted_block;
 
 public:

--- a/src/selecttool.h
+++ b/src/selecttool.h
@@ -37,7 +37,7 @@ public:
     void saveSettings(QSettings * settings);
     void onClicked(const QPoint & pt);
     void onMouseMove(const QPoint & pt);
-    const BlockObject * getSelectedBlock() const;
+    const std::shared_ptr<BlockObject> getSelectedBlock() const;
 
 public slots:
     void onDeselect();
@@ -68,9 +68,9 @@ protected:
 
     EModeSelect select_mode;
     Selection * selection;
-    BlockObject * selected_block;
+    std::shared_ptr<BlockObject> selected_block;
     Selection * highlight;
-    BlockObject * highlighted_block;
+    std::shared_ptr<BlockObject> highlighted_block;
 
 public:
     static QColor SELECTION_CLR;

--- a/src/stlreader.cpp
+++ b/src/stlreader.cpp
@@ -6,16 +6,12 @@
 
 STLReader::STLReader(const std::string & file_name) : Reader(file_name), reader(nullptr) {}
 
-STLReader::~STLReader()
-{
-    if (this->reader)
-        this->reader->Delete();
-}
+STLReader::~STLReader() {}
 
 void
 STLReader::load()
 {
-    this->reader = vtkSTLReader::New();
+    this->reader = vtkSmartPointer<vtkSTLReader>::New();
 
     this->reader->SetFileName(this->file_name.c_str());
     this->reader->Update();

--- a/src/stlreader.h
+++ b/src/stlreader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "reader.h"
+#include "vtkSmartPointer.h"
 #include <map>
 
 class vtkSTLReader;
@@ -26,6 +27,6 @@ public:
 protected:
     void readBlockInfo();
 
-    vtkSTLReader * reader;
+    vtkSmartPointer<vtkSTLReader> reader;
     std::map<int, BlockInformation> block_info;
 };

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -49,7 +49,6 @@ View::View(MainWindow * main_wnd) :
     ori_marker(nullptr),
     render_window(vtkSmartPointer<vtkGenericOpenGLRenderWindow>::New()),
     renderer(vtkSmartPointer<vtkRenderer>::New()),
-    interactor(nullptr),
     interactor_style_2d(new OInteractorStyle2D(this->main_window)),
     interactor_style_3d(new OInteractorStyle3D(this->main_window)),
     cube_axes_actor(nullptr)
@@ -153,8 +152,6 @@ View::updateMenuBar(bool enabled)
 void
 View::setupVtk()
 {
-    this->interactor = this->render_window->GetInteractor();
-
     // TODO: set background from preferences/templates
     this->renderer->SetGradientBackground(true);
     // set anti-aliasing on
@@ -506,11 +503,12 @@ View::setupOrientationMarker()
         text_prop->ShadowOff();
     }
 
+    auto interactor = this->render_window->GetInteractor();
     this->ori_marker = vtkSmartPointer<vtkOrientationMarkerWidget>::New();
     this->ori_marker->SetDefaultRenderer(this->renderer);
     this->ori_marker->SetOrientationMarker(axes);
     this->ori_marker->SetViewport(0.8, 0, 1.0, 0.2);
-    this->ori_marker->SetInteractor(this->interactor);
+    this->ori_marker->SetInteractor(interactor);
     this->ori_marker->SetEnabled(true);
     this->ori_marker->SetInteractive(false);
 }
@@ -518,10 +516,11 @@ View::setupOrientationMarker()
 void
 View::setInteractorStyle(int dim)
 {
+    auto interactor = this->render_window->GetInteractor();
     if (dim == 3)
-        this->interactor->SetInteractorStyle(this->interactor_style_3d);
+        interactor->SetInteractorStyle(this->interactor_style_3d);
     else
-        this->interactor->SetInteractorStyle(this->interactor_style_2d);
+        interactor->SetInteractorStyle(this->interactor_style_2d);
 }
 
 void

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -170,7 +170,7 @@ View::clear()
 }
 
 void
-View::addBlock(BlockObject * block)
+View::addBlock(std::shared_ptr<BlockObject> block)
 {
     setBlockProperties(block);
     this->renderer->AddViewProp(block->getActor());
@@ -179,14 +179,14 @@ View::addBlock(BlockObject * block)
 }
 
 void
-View::addSideSet(SideSetObject * sideset)
+View::addSideSet(std::shared_ptr<SideSetObject> sideset)
 {
     setSideSetProperties(sideset);
     this->renderer->AddViewProp(sideset->getActor());
 }
 
 void
-View::addNodeSet(NodeSetObject * nodeset)
+View::addNodeSet(std::shared_ptr<NodeSetObject> nodeset)
 {
     this->setNodeSetProperties(nodeset);
     this->renderer->AddViewProp(nodeset->getActor());
@@ -197,17 +197,14 @@ View::onShadedTriggered(bool checked)
 {
     this->render_mode = SHADED;
     auto blocks = this->model->getBlocks();
-    for (auto & it : blocks) {
-        auto * block = it.second;
+    for (auto & [id, block] : blocks) {
         bool selected = this->main_window->getSelectedBlock() == block;
         setBlockProperties(block, selected);
         block->setSilhouetteVisible(false);
     }
     auto side_sets = this->model->getSideSets();
-    for (auto & it : side_sets) {
-        auto * sideset = it.second;
+    for (auto & [id, sideset] : side_sets)
         setSideSetProperties(sideset);
-    }
 }
 
 void
@@ -215,17 +212,14 @@ View::onShadedWithEdgesTriggered(bool checked)
 {
     this->render_mode = SHADED_WITH_EDGES;
     auto blocks = this->model->getBlocks();
-    for (auto & it : blocks) {
-        auto * block = it.second;
+    for (auto & [id, block] : blocks) {
         bool selected = this->main_window->getSelectedBlock() == block;
         setBlockProperties(block, selected);
         block->setSilhouetteVisible(false);
     }
     auto side_sets = this->model->getSideSets();
-    for (auto & it : side_sets) {
-        auto * sideset = it.second;
+    for (auto & [id, sideset] : side_sets)
         setSideSetProperties(sideset);
-    }
 }
 
 void
@@ -233,17 +227,14 @@ View::onHiddenEdgesRemovedTriggered(bool checked)
 {
     this->render_mode = HIDDEN_EDGES_REMOVED;
     auto blocks = this->model->getBlocks();
-    for (auto & it : blocks) {
-        auto * block = it.second;
+    for (auto & [id, block] : blocks) {
         bool selected = this->main_window->getSelectedBlock() == block;
         setBlockProperties(block, selected);
         block->setSilhouetteVisible(block->visible());
     }
     auto side_sets = this->model->getSideSets();
-    for (auto & it : side_sets) {
-        auto * sideset = it.second;
+    for (auto & [id, sideset] : side_sets)
         setSideSetProperties(sideset);
-    }
 }
 
 void
@@ -251,17 +242,14 @@ View::onTransluentTriggered(bool checked)
 {
     this->render_mode = TRANSLUENT;
     auto blocks = this->model->getBlocks();
-    for (auto & it : blocks) {
-        auto * block = it.second;
+    for (auto & [id, block] : blocks) {
         bool selected = this->main_window->getSelectedBlock() == block;
         setBlockProperties(block, selected);
         block->setSilhouetteVisible(block->visible());
     }
     auto side_sets = this->model->getSideSets();
-    for (auto & it : side_sets) {
-        auto * sideset = it.second;
+    for (auto & [id, sideset] : side_sets)
         setSideSetProperties(sideset);
-    }
 }
 
 void
@@ -301,7 +289,7 @@ View::onColorProfileChanged(ColorProfile * profile)
 }
 
 void
-View::setSelectedBlockProperties(BlockObject * block, bool highlighted)
+View::setSelectedBlockProperties(std::shared_ptr<BlockObject> block, bool highlighted)
 {
     auto * property = block->getProperty();
     if (this->render_mode == SHADED) {
@@ -333,7 +321,7 @@ View::setSelectedBlockProperties(BlockObject * block, bool highlighted)
 }
 
 void
-View::setDeselectedBlockProperties(BlockObject * block, bool highlighted)
+View::setDeselectedBlockProperties(std::shared_ptr<BlockObject> block, bool highlighted)
 {
     auto * property = block->getProperty();
     if (this->render_mode == SHADED) {
@@ -368,7 +356,7 @@ View::setDeselectedBlockProperties(BlockObject * block, bool highlighted)
 }
 
 void
-View::setHighlightedBlockProperties(BlockObject * block, bool highlighted)
+View::setHighlightedBlockProperties(std::shared_ptr<BlockObject> block, bool highlighted)
 {
     auto * property = block->getSilhouetteProperty();
     if (highlighted) {
@@ -420,7 +408,7 @@ View::setHighlightedBlockProperties(BlockObject * block, bool highlighted)
 }
 
 void
-View::setBlockProperties(BlockObject * block, bool selected, bool highlighted)
+View::setBlockProperties(std::shared_ptr<BlockObject> block, bool selected, bool highlighted)
 {
     auto * property = block->getProperty();
     property->SetRepresentationToSurface();
@@ -433,7 +421,7 @@ View::setBlockProperties(BlockObject * block, bool selected, bool highlighted)
 }
 
 void
-View::setSideSetProperties(SideSetObject * sideset)
+View::setSideSetProperties(std::shared_ptr<SideSetObject> sideset)
 {
     auto * property = sideset->getProperty();
     property->SetColor(SIDESET_CLR.redF(), SIDESET_CLR.greenF(), SIDESET_CLR.blueF());
@@ -461,7 +449,7 @@ View::setSideSetProperties(SideSetObject * sideset)
 }
 
 void
-View::setNodeSetProperties(NodeSetObject * nodeset)
+View::setNodeSetProperties(std::shared_ptr<NodeSetObject> nodeset)
 {
     auto * property = nodeset->getProperty();
     property->SetRepresentationToPoints();
@@ -536,7 +524,7 @@ View::resetCamera()
 void
 View::setBlockVisibility(int block_id, bool visible)
 {
-    BlockObject * block = this->model->getBlock(block_id);
+    auto block = this->model->getBlock(block_id);
     if (block) {
         block->setVisible(visible);
         if (this->render_mode == HIDDEN_EDGES_REMOVED || this->render_mode == TRANSLUENT)
@@ -549,7 +537,7 @@ View::setBlockVisibility(int block_id, bool visible)
 void
 View::setBlockOpacity(int block_id, double opacity)
 {
-    BlockObject * block = this->model->getBlock(block_id);
+    auto block = this->model->getBlock(block_id);
     if (block) {
         block->setOpacity(opacity);
         if (this->render_mode == SHADED || this->render_mode == SHADED_WITH_EDGES) {
@@ -562,7 +550,7 @@ View::setBlockOpacity(int block_id, double opacity)
 void
 View::setBlockColor(int block_id, QColor color)
 {
-    BlockObject * block = this->model->getBlock(block_id);
+    auto block = this->model->getBlock(block_id);
     if (block) {
         block->setColor(color);
         auto * property = block->getProperty();
@@ -576,7 +564,7 @@ View::setBlockColor(int block_id, QColor color)
 void
 View::setSideSetVisibility(int sideset_id, bool visible)
 {
-    auto * sideset = this->model->getSideSet(sideset_id);
+    auto sideset = this->model->getSideSet(sideset_id);
     if (sideset)
         sideset->setVisible(visible);
 }
@@ -584,7 +572,7 @@ View::setSideSetVisibility(int sideset_id, bool visible)
 void
 View::setNodeSetVisibility(int nodeset_id, bool visible)
 {
-    auto * nodeset = this->model->getNodeSet(nodeset_id);
+    auto nodeset = this->model->getNodeSet(nodeset_id);
     if (nodeset)
         nodeset->setVisible(visible);
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -47,8 +47,8 @@ View::View(MainWindow * main_wnd) :
     perspective_action(nullptr),
     ori_marker_action(nullptr),
     ori_marker(nullptr),
-    render_window(vtkGenericOpenGLRenderWindow::New()),
-    renderer(vtkRenderer::New()),
+    render_window(vtkSmartPointer<vtkGenericOpenGLRenderWindow>::New()),
+    renderer(vtkSmartPointer<vtkRenderer>::New()),
     interactor(nullptr),
     interactor_style_2d(new OInteractorStyle2D(this->main_window)),
     interactor_style_3d(new OInteractorStyle3D(this->main_window)),
@@ -62,8 +62,6 @@ View::~View()
 {
     delete this->view_menu;
     delete this->view_mode;
-    this->render_window->Delete();
-    this->renderer->Delete();
 }
 
 vtkCamera *
@@ -485,7 +483,7 @@ View::setupOrientationMarker()
 {
     std::array<QColor, 3> clr({ QColor(188, 39, 26), QColor(65, 147, 41), QColor(0, 0, 200) });
 
-    vtkAxesActor * axes = vtkAxesActor::New();
+    auto axes = vtkSmartPointer<vtkAxesActor>::New();
     axes->SetNormalizedTipLength(0, 0, 0);
 
     std::array<vtkProperty *, 3> shaft_property({ axes->GetXAxisShaftProperty(),
@@ -508,7 +506,7 @@ View::setupOrientationMarker()
         text_prop->ShadowOff();
     }
 
-    this->ori_marker = vtkOrientationMarkerWidget::New();
+    this->ori_marker = vtkSmartPointer<vtkOrientationMarkerWidget>::New();
     this->ori_marker->SetDefaultRenderer(this->renderer);
     this->ori_marker->SetOrientationMarker(axes);
     this->ori_marker->SetViewport(0.8, 0, 1.0, 0.2);
@@ -628,7 +626,7 @@ View::activateRenderMode()
 void
 View::setupCubeAxesActor()
 {
-    this->cube_axes_actor = vtkCubeAxesActor::New();
+    this->cube_axes_actor = vtkSmartPointer<vtkCubeAxesActor>::New();
     this->cube_axes_actor->VisibilityOff();
     this->cube_axes_actor->SetCamera(getActiveCamera());
     this->cube_axes_actor->SetGridLineLocation(vtkCubeAxesActor::VTK_GRID_LINES_ALL);

--- a/src/view.h
+++ b/src/view.h
@@ -42,12 +42,14 @@ public:
     void clear();
     void setupOrientationMarker();
     vtkCamera * getActiveCamera();
-    void addBlock(BlockObject * block);
-    void addSideSet(SideSetObject * sideset);
-    void addNodeSet(NodeSetObject * nodeset);
+    void addBlock(std::shared_ptr<BlockObject> block);
+    void addSideSet(std::shared_ptr<SideSetObject> sideset);
+    void addNodeSet(std::shared_ptr<NodeSetObject> nodeset);
     void setInteractorStyle(int dim);
     void resetCamera();
-    void setBlockProperties(BlockObject * block, bool selected = false, bool highlighted = false);
+    void setBlockProperties(std::shared_ptr<BlockObject> block,
+                            bool selected = false,
+                            bool highlighted = false);
     void setBlockVisibility(int block_id, bool visible);
     void setBlockOpacity(int block_id, double opacity);
     void setBlockColor(int block_id, QColor color);
@@ -72,11 +74,11 @@ public slots:
 
 protected:
     void setupViewModeWidget();
-    void setSelectedBlockProperties(BlockObject * block, bool highlighted = false);
-    void setDeselectedBlockProperties(BlockObject * block, bool highlighted = false);
-    void setHighlightedBlockProperties(BlockObject * block, bool highlighted);
-    void setSideSetProperties(SideSetObject * sideset);
-    void setNodeSetProperties(NodeSetObject * nodeset);
+    void setSelectedBlockProperties(std::shared_ptr<BlockObject> block, bool highlighted = false);
+    void setDeselectedBlockProperties(std::shared_ptr<BlockObject> block, bool highlighted = false);
+    void setHighlightedBlockProperties(std::shared_ptr<BlockObject> block, bool highlighted);
+    void setSideSetProperties(std::shared_ptr<SideSetObject> sideset);
+    void setNodeSetProperties(std::shared_ptr<NodeSetObject> nodeset);
     void setupCubeAxesActor();
     void setCubeAxesColors(ColorProfile * profile);
 

--- a/src/view.h
+++ b/src/view.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "QVTKOpenGLNativeWidget.h"
+#include "vtkSmartPointer.h"
 
 class MainWindow;
 class Model;
@@ -92,13 +93,13 @@ protected:
     QActionGroup * visual_repr;
     QAction * perspective_action;
     QAction * ori_marker_action;
-    vtkOrientationMarkerWidget * ori_marker;
-    vtkGenericOpenGLRenderWindow * render_window;
-    vtkRenderer * renderer;
+    vtkSmartPointer<vtkOrientationMarkerWidget> ori_marker;
+    vtkSmartPointer<vtkGenericOpenGLRenderWindow> render_window;
+    vtkSmartPointer<vtkRenderer> renderer;
     vtkRenderWindowInteractor * interactor;
     OInteractorStyle2D * interactor_style_2d;
     OInteractorStyle3D * interactor_style_3d;
-    vtkCubeAxesActor * cube_axes_actor;
+    vtkSmartPointer<vtkCubeAxesActor> cube_axes_actor;
 
 public:
     static QColor SIDESET_CLR;

--- a/src/view.h
+++ b/src/view.h
@@ -13,7 +13,6 @@ class QPushButton;
 class QAction;
 class QActionGroup;
 class vtkOrientationMarkerWidget;
-class vtkRenderWindowInteractor;
 class BlockObject;
 class SideSetObject;
 class NodeSetObject;
@@ -96,7 +95,6 @@ protected:
     vtkSmartPointer<vtkOrientationMarkerWidget> ori_marker;
     vtkSmartPointer<vtkGenericOpenGLRenderWindow> render_window;
     vtkSmartPointer<vtkRenderer> renderer;
-    vtkRenderWindowInteractor * interactor;
     OInteractorStyle2D * interactor_style_2d;
     OInteractorStyle3D * interactor_style_3d;
     vtkSmartPointer<vtkCubeAxesActor> cube_axes_actor;

--- a/src/vtkextractmaterialblock.cpp
+++ b/src/vtkextractmaterialblock.cpp
@@ -49,7 +49,7 @@ vtkExtractMaterialBlock::RequestData(vtkInformation * request,
     // for GlobalIds array so that, if present, it will be copied to the output.
     output_cd->CopyGlobalIdsOn();
 
-    auto new_cell_pts = vtkIdList::New();
+    auto new_cell_pts = vtkSmartPointer<vtkIdList>::New();
     new_cell_pts->Allocate(VTK_CELL_SIZE);
 
     vtkIdType n_pts = input->GetNumberOfPoints();
@@ -59,7 +59,7 @@ vtkExtractMaterialBlock::RequestData(vtkInformation * request,
         point_map[i] = -1;
 
     output->Allocate(n_cells / 4); // allocate storage for geometry/topology
-    auto new_pts = vtkPoints::New();
+    auto new_pts = vtkSmartPointer<vtkPoints>::New();
     new_pts->Allocate(n_pts / 4, n_pts);
     output_cd->CopyAllocate(cd);
 
@@ -91,9 +91,7 @@ vtkExtractMaterialBlock::RequestData(vtkInformation * request,
     }
 
     delete[] point_map;
-    new_cell_pts->Delete();
     output->SetPoints(new_pts);
-    new_pts->Delete();
 
     output->Squeeze();
 

--- a/src/vtkmshreader.h
+++ b/src/vtkmshreader.h
@@ -31,11 +31,7 @@ public:
     virtual vtkIdType GetTotalNumberOfFaces();
     virtual vtkIdType GetTotalNumberOfElements();
 
-    vtkMutableDirectedGraph *
-    GetSIL()
-    {
-        return this->SIL;
-    }
+    vtkMutableDirectedGraph * GetSIL();
 
     enum ObjectType { ELEM_BLOCK = 0, SIDE_SET = 1 };
 
@@ -67,7 +63,7 @@ protected:
 
     char * FileName;
     vtkTimeStamp FileNameMTime;
-    vtkMutableDirectedGraph * SIL;
+    vtkSmartPointer<vtkMutableDirectedGraph> SIL;
     int SILUpdateStamp;
     gmshparsercpp::MshFile * Msh;
     /// Spatial dimension

--- a/src/vtkreader.cpp
+++ b/src/vtkreader.cpp
@@ -24,24 +24,18 @@ VTKReader::VTKReader(const std::string & file_name) :
 {
 }
 
-VTKReader::~VTKReader()
-{
-    if (this->reader)
-        this->reader->Delete();
-    if (this->xml_reader)
-        this->xml_reader->Delete();
-}
+VTKReader::~VTKReader() {}
 
 void
 VTKReader::load()
 {
     if (endsWith(this->file_name, ".vtk")) {
-        this->reader = vtkUnstructuredGridReader::New();
+        this->reader = vtkSmartPointer<vtkUnstructuredGridReader>::New();
         this->reader->SetFileName(this->file_name.c_str());
         this->reader->Update();
     }
     else if (endsWith(this->file_name, ".vtu")) {
-        this->xml_reader = vtkXMLUnstructuredGridReader::New();
+        this->xml_reader = vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
         this->xml_reader->SetFileName(this->file_name.c_str());
         this->xml_reader->Update();
 

--- a/src/vtkreader.h
+++ b/src/vtkreader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "reader.h"
+#include "vtkSmartPointer.h"
 #include <map>
 
 class vtkUnstructuredGridReader;
@@ -27,7 +28,7 @@ public:
 protected:
     void readBlockInfo();
 
-    vtkUnstructuredGridReader * reader;
-    vtkXMLUnstructuredGridReader * xml_reader;
+    vtkSmartPointer<vtkUnstructuredGridReader> reader;
+    vtkSmartPointer<vtkXMLUnstructuredGridReader> xml_reader;
     std::map<int, BlockInformation> block_info;
 };


### PR DESCRIPTION
- Use VTK smart pointers for managing VTK objects
- Removing `interactor` member variable
- Blocks, side sets, and node sets are stored as shared_ptr
- Moar std::shared_ptr
- Use shared_ptr for Selection
